### PR TITLE
Add validation for curl output of ips.txt

### DIFF
--- a/arvancloud-sync-ips.sh
+++ b/arvancloud-sync-ips.sh
@@ -1,13 +1,24 @@
 #!/bin/bash
 
 ARVANCLOUD_FILE_PATH=/etc/nginx/arvancloud
+ARVANCLOUD_CDN_IPS_TXT_URL="https://www.arvancloud.com/fa/ips.txt"
+
+VALID_IP_OCTET_REGEX="(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+IP_WITH_SUBNET_REGEX="^$VALID_IP_OCTET_REGEX\.$VALID_IP_OCTET_REGEX\.$VALID_IP_OCTET_REGEX\.$VALID_IP_OCTET_REGEX\/[0-9]+$"
+IP_ADDRS=$(curl -s -L $ARVANCLOUD_CDN_IPS_TXT_URL | grep -E -o "$IP_WITH_SUBNET_REGEX")
+
+if [ -z "$IP_ADDRS" ];
+then
+  echo "Couldn't extract CDN any ip address from $ARVANCLOUD_CDN_IPS_TXT_URL"
+  exit 1
+fi
 
 echo "#Arvan" > $ARVANCLOUD_FILE_PATH;
 echo "" >> $ARVANCLOUD_FILE_PATH;
 
 echo "# - IPv4" >> $ARVANCLOUD_FILE_PATH;
-for i in `curl https://www.arvancloud.com/fa/ips.txt`; do
-        echo "set_real_ip_from $i;" >> $ARVANCLOUD_FILE_PATH;
+for ip in $IP_ADDRS; do
+  echo "set_real_ip_from $ip;" >> $ARVANCLOUD_FILE_PATH;
 done
 
 echo "" >> $ARVANCLOUD_FILE_PATH;


### PR DESCRIPTION
It seems that bot detection is blocked `curl` request to  https://www.arvancloud.com/fa/ips.txt.
So I think the script should validate the output before manipulating nginx configuration file.

![image](https://user-images.githubusercontent.com/22779039/105256881-de25a680-5b9b-11eb-88b8-1711e3df2c91.png)